### PR TITLE
Gitian-Build.py fixes for docker

### DIFF
--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -200,7 +200,7 @@ def build():
         print('\nCompiling ' + args.version + ' MacOS')
         subprocess.check_call(['bin/gbuild', '-j', args.jobs, '-m', args.memory, '--commit', 'AltmarketsCoin='+args.commit, '--url', 'AltmarketsCoin='+args.url, '../AltmarketsCoin/contrib/gitian-descriptors/gitian-osx.yml'])
         subprocess.check_call(['bin/gsign', '-p', args.sign_prog, '--signer', args.signer, '--release', args.version+'-osx-unsigned', '--destination', '../gitian.sigs.altmarkets/', '../AltmarketsCoin/contrib/gitian-descriptors/gitian-osx.yml'])
-        subprocess.check_call('mv build/out/altmarkets-*-osx-unsigned.tar.gz inputs/altmarkets-osx-unsigned.tar.gz', shell=True)
+        subprocess.check_call('mv build/out/altmarkets-*-osx-unsigned.tar.gz inputs/Altmarkets-osx-unsigned.tar.gz', shell=True)
         subprocess.check_call('mv build/out/altmarkets-*.tar.gz build/out/altmarkets-*.dmg build/out/src/altmarkets-*.tar.gz ../altmarkets-binaries/'+args.version + '/mac', shell=True)
         try:
             subprocess.check_call('mv var/install.log var/install_mac.log', shell=True)
@@ -249,7 +249,7 @@ def sign():
         except:
             pass
         try:
-            subprocess.check_call('mv build/out/altmarkets-osx-signed.dmg ../altmarkets-binaries/' + args.version + '/mac' + '/altmarkets-'+args.version+'-osx.dmg', shell=True)
+            subprocess.check_call('mv build/out/Altmarkets-osx-signed.dmg ../altmarkets-binaries/' + args.version + '/mac' + '/Altmarkets-'+args.version+'-osx.dmg', shell=True)
         except Exception as e:
             print(e)
             pass

--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -378,7 +378,8 @@ def main():
     os.environ['USE_DOCKER'] = ''
     if args.docker:
         os.environ['USE_DOCKER'] = '1'
-        os.environ['MIRROR_HOST'] = 'no-cache'
+        if args.no_apt_proxy:
+            os.environ['MIRROR_HOST'] = 'no-cache'
     elif not args.kvm:
         os.environ['USE_LXC'] = '1'
         if 'GITIAN_HOST_IP' not in os.environ.keys():

--- a/contrib/gitian-build.py
+++ b/contrib/gitian-build.py
@@ -376,10 +376,10 @@ def main():
     os.environ['USE_LXC'] = ''
     os.environ['USE_VBOX'] = ''
     os.environ['USE_DOCKER'] = ''
+    if args.no_apt_proxy:
+        os.environ['MIRROR_HOST'] = 'no-cache'
     if args.docker:
         os.environ['USE_DOCKER'] = '1'
-        if args.no_apt_proxy:
-            os.environ['MIRROR_HOST'] = 'no-cache'
     elif not args.kvm:
         os.environ['USE_LXC'] = '1'
         if 'GITIAN_HOST_IP' not in os.environ.keys():


### PR DESCRIPTION
Some fixes here to make things easier gitian building with `--docker`

I'm testing this with Ubuntu Trusty, there's a lot less user setup involved than with LXC.

`python3 gitian-build.py --docker --upgrade-git --no-apt-proxy --setup $SIGNER_NAME $VERSION`
`python3 gitian-build.py --docker --detach-sign --build $SIGNER_NAME $VERSION`